### PR TITLE
Github Discord Bot Service

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
     "prefix": "s!",
     "API_TOKEN": "token goes here",
+    "SCE_GITHUB_API_URL": "http://localhost:8085",
     "SCE_GOOGLE_API_URL": "http://localhost:8082",
     "EVENTS_CAL": ""
 }

--- a/src/commands/member_services/github.js
+++ b/src/commands/member_services/github.js
@@ -1,0 +1,77 @@
+const Discord = require('discord.js');
+const Command = require('../Command');
+const { GithubMessageGenerator } = require('../../util/GithubMessageGenerator');
+
+/**
+ * commands that grabs Github data from SCE server
+ * pr <repoName> -> Open Pull Requests
+ * leaderboard <repoName> -> Top 5 contributors
+ * commits <repoName> <numOfCommits> -> Merged Commits
+ */
+module.exports = new Command({
+  name: 'github',
+  description: 'Displays following information from SCE github repos:\
+  Contributor leaderboard, Pull requests, merged commits',
+  category: 'github',
+  aliases: ['git'],
+  permissions: 'general',
+
+  execute: (message, args) => {
+    const messageGenerator = new GithubMessageGenerator();
+
+    switch(args[0]) {
+    case 'pr':
+      messageGenerator.generatePullRequestMessage(args[1])
+        .then(prMessage => {
+          message.channel.send(prMessage);
+        })
+        .catch(_ => {
+          message.channel.send(_);
+        });
+      break;
+  
+    case 'leaderboard':
+      messageGenerator.generateLeaderboardMessage(args[1])
+        .then(leaderboardMessage => {
+          leaderboardMessage.forEach(embed => {
+            message.channel.send(embed);
+          });
+        })
+        .catch(_ => {
+          message.channel.send(_);
+        });
+      break;
+
+    case 'commits':
+      // Check if 3rd argument (optional) is a number
+      if(args[2] && isNaN(args[2])) {
+        message.channel.send(
+          `Invalid Value: ${args[2]} Please enter a number`
+        );
+        break;
+      }
+      messageGenerator.generateCommitMessage(args[1], args[2])
+        .then(commitMessage => {
+          message.channel.send(commitMessage);
+        })
+        .catch(_ => {
+          message.channel.send(_);
+        });
+      break;
+
+    default:
+      // Help
+      message.channel.send(
+        new Discord.RichEmbed()
+          .setDescription('Unrecognized parameter try using:')
+          .addField('pr <repo>', 'View pull requests')
+          .addField('leaderboard <repo>', 'Top 5 contributors')
+          .addField(
+            'commits <repo> <num>',
+            'Merged commits - <num> (optional, Limit: 25)'
+          )
+      );
+    }
+  },
+});
+

--- a/src/util/GithubFetcher.js
+++ b/src/util/GithubFetcher.js
@@ -1,0 +1,88 @@
+const fetch = require('node-fetch');
+const { SCE_GITHUB_API_URL } = require('../../config.json');
+
+/**
+ * Class that communicates with SCE server's Github API to
+ * retrieve data from Github
+ */
+class GithubFetcher {
+  /**
+   * Creates GithubFetcher object
+   */
+  constructor() {
+
+  }
+
+  /**
+   * This function retrieves a list of users that have contributed to a
+   * defined repo in the past month
+   * @param {*} repo Name of SCE repository
+   * @returns {Promise} Contributors
+   */
+  fetchLeaderboard(repo) {
+    return new Promise((resolve, reject) => {
+      fetch(`${SCE_GITHUB_API_URL}/api/routes/` +
+      `getContributorsInPastMonthFromRepo?repository=${repo}`
+      )
+        .then(data => data.json())
+        .then(object => {
+          resolve(object.contributors);
+        })
+        .catch(_ => {
+          reject(_);
+        });
+    });
+  }
+
+  /**
+   * This function retrieves a list of active pull requests from
+   * the defined repo
+   * @param {String} repo Name of SCE repository
+   * @returns {Promise} Pull Requests LIMIT OF 25
+   */
+  fetchPullRequests(repo) {
+    return new Promise((resolve, reject) => {
+      fetch(`${SCE_GITHUB_API_URL}/api/routes/` +
+        `getPullRequestsFromRepo?repository=${repo}`
+      )
+        .then(data => data.json())
+        .then(object => {
+          const pullRequests = object.pullRequests.map(pr => ({
+            name: `#${pr.number} ${pr.title}`,
+            value: `[view](${pr.pullRequestUrl})`
+          }));
+          resolve(pullRequests.slice(0, 25));
+        })
+        .catch(_ => {
+          reject(_);
+        });
+    });
+  }
+
+  /**
+   * This function retrieves a list of commits from the
+   * the defined repo
+   * @param {String} repo Name of SCE repository
+   * @returns {Promise} Commits
+   */
+  fetchCommits(repo) {
+    return new Promise((resolve, reject) => {
+      fetch(`${SCE_GITHUB_API_URL}/api/routes/` +
+        `getCommitsFromRepo?repository=${repo}`
+      )
+        .then(data => data.json())
+        .then(object => {
+          const commits = object.commits.map(commit => ({
+            name: `#${commit.user}`,
+            value: `[${commit.message}](${commit.commitUrl})`
+          }));
+          resolve(commits);
+        })
+        .catch(_ => {
+          reject(_);
+        });
+    });
+  }
+}
+
+module.exports = { GithubFetcher };

--- a/src/util/GithubMessageGenerator.js
+++ b/src/util/GithubMessageGenerator.js
@@ -1,0 +1,106 @@
+const Discord = require('discord.js');
+const { GithubFetcher } = require('./GithubFetcher');
+
+/**
+ * Class formats the Github embed messages that are sent on
+ * command execution.
+ */
+class GithubMessageGenerator {
+  constructor() {
+    this.fetcher = new GithubFetcher();
+    this.defaultEmbed = {
+      color: '2672614',
+      thumbnail: {
+        url: 'https://github.githubassets.com' +
+          '/images/modules/logos_page/Octocat.png'
+      }
+    };
+  }
+  
+  /**
+   * Generates an embed message containing the details of each
+   * open pull request in the repository
+   * @param {String} repo Name of SCE repository
+   * @returns {Promise} Embed with pull request details in the field parameter
+   */
+  generatePullRequestMessage(repo) {
+    return new Promise((resolve, reject) => {
+      this.fetcher.fetchPullRequests(repo)
+        .then(pullRequests => {
+          this.defaultEmbed.title = `Pull Requests - ${repo}`;
+          this.defaultEmbed.url =
+            `https://github.com/SCE-Development/${repo}/pulls`;
+          this.defaultEmbed.description =
+            'Active pull requests in this repository';
+          this.defaultEmbed.fields = pullRequests;
+          resolve({embed: this.defaultEmbed});
+        })
+        .catch(_ => {
+          if(_)
+            reject(`There is no repository named ${repo}`);
+        });
+    });
+  }
+  
+  /**
+   * Generates a list of embed messages including the details of the
+   * top 5 contributors in the repo
+   * @param {String} repo Name of SCE repository
+   * @returns {Promise} Array<Embeds>
+   */
+  generateLeaderboardMessage(repo) {
+    return new Promise((resolve, reject) => {
+      this.fetcher.fetchLeaderboard(repo)
+        .then(leaderboard => {
+          const embeds = [];
+          let rank = 1;
+  
+          leaderboard.forEach(({user, avatarUrl, commits}) => {
+            const embed = new Discord.RichEmbed()
+              .setColor('28C7E6')
+              .setAuthor(`${rank}. ${user}`, avatarUrl)
+              .setDescription(`${commits} Commits`);
+            if(rank == 1) {
+              embed.description = `:crown: ${embed.description} :crown:`;
+            }
+            rank++;
+            embeds.push(embed);
+          });
+
+          resolve(embeds);
+        })
+        .catch(_ => {
+          if(_)
+            reject(`There is no repository named ${repo}`);
+        });
+    });
+  }
+  
+  /**
+   * 
+   * @param {String} repo Name of SCE repository
+   * @param {Integer} numOfCommits Number of commits to be shown
+   * Limit of 25. Defined in GithubFetcher.fetchCommits
+   * @returns {Promise} Embed with commit details in the field parameter
+   */
+  generateCommitMessage(repo, numOfCommits=1) {
+    return new Promise((resolve, reject) => {
+      this.fetcher.fetchCommits(repo)
+        .then(commits => {
+          this.defaultEmbed.title = `Commit(s) - ${repo}`;
+          this.defaultEmbed.url = 
+            `https://github.com/SCE-Development/${repo}/commits`;
+          this.defaultEmbed.description =
+            'Merged commit(s) from this repository';
+          this.defaultEmbed.fields = commits.slice(0, numOfCommits);
+          resolve({embed: this.defaultEmbed});
+        })
+        .catch(_ => {
+          if(_)
+            reject(`There is no repository named ${repo}`);
+        });
+    });
+  }
+}
+
+module.exports = { GithubMessageGenerator };


### PR DESCRIPTION
Created commands that display the following for the repo defined in the argument:
- Commit Leaderboard
- Open Pull requests
- Merged Commits

Steps to run:

    1. Ensure the config.json file in the root folder has the following properties:
        {
        "prefix": "s!",
        "API_TOKEN": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        "SCE_GITHUB_API_URL": "http://localhost:8085"
        }

    2. run 'npm run server' in root folder of Core-V4 project to open comminucation to Github Api server

    3. run 'npm start' in root folder of SCE-Discord-Bot project
    
    4. In Discord server run any of the following commands:
        command: github
        alias: git

        -> s!github leaderboard <repoName>
        This will display the top 5 contributors in the repo defined in the argument

        -> s!github pr
        This will display all the open pull requests in teh repo defined in the argument

        -> s!github commits <repoName> <numOfCommits>
        This will display a list of commits that have been recently merged into the repo (Limit of 25)
        *NOTE* <numOfCommits> argument is optional