### PR TITLE
feat: Add CLI help command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
     "rules": {
         "indent": [
             "error",
-            2
+            2,
+            {"SwitchCase": 1}
         ],
         "quotes": [
             "error",

--- a/src/commands/member_services/github.js
+++ b/src/commands/member_services/github.js
@@ -20,57 +20,57 @@ module.exports = new Command({
     const messageGenerator = new GithubMessageGenerator();
 
     switch(args[0]) {
-    case 'pr':
-      messageGenerator.generatePullRequestMessage(args[1])
-        .then(prMessage => {
-          message.channel.send(prMessage);
-        })
-        .catch(_ => {
-          message.channel.send(_);
-        });
-      break;
-  
-    case 'leaderboard':
-      messageGenerator.generateLeaderboardMessage(args[1])
-        .then(leaderboardMessage => {
-          leaderboardMessage.forEach(embed => {
-            message.channel.send(embed);
+      case 'pr':
+        messageGenerator.generatePullRequestMessage(args[1])
+          .then(prMessage => {
+            message.channel.send(prMessage);
+          })
+          .catch(_ => {
+            message.channel.send(_);
           });
-        })
-        .catch(_ => {
-          message.channel.send(_);
-        });
-      break;
-
-    case 'commits':
-      // Check if 3rd argument (optional) is a number
-      if(args[2] && isNaN(args[2])) {
-        message.channel.send(
-          `Invalid Value: ${args[2]} Please enter a number`
-        );
         break;
-      }
-      messageGenerator.generateCommitMessage(args[1], args[2])
-        .then(commitMessage => {
-          message.channel.send(commitMessage);
-        })
-        .catch(_ => {
-          message.channel.send(_);
-        });
-      break;
+    
+      case 'leaderboard':
+        messageGenerator.generateLeaderboardMessage(args[1])
+          .then(leaderboardMessage => {
+            leaderboardMessage.forEach(embed => {
+              message.channel.send(embed);
+            });
+          })
+          .catch(_ => {
+            message.channel.send(_);
+          });
+        break;
 
-    default:
-      // Help
-      message.channel.send(
-        new Discord.RichEmbed()
-          .setDescription('Unrecognized parameter try using:')
-          .addField('pr <repo>', 'View pull requests')
-          .addField('leaderboard <repo>', 'Top 5 contributors')
-          .addField(
-            'commits <repo> <num>',
-            'Merged commits - <num> (optional, Limit: 25)'
-          )
-      );
+      case 'commits':
+        // Check if 3rd argument (optional) is a number
+        if(args[2] && isNaN(args[2])) {
+          message.channel.send(
+            `Invalid Value: ${args[2]} Please enter a number`
+          );
+          break;
+        }
+        messageGenerator.generateCommitMessage(args[1], args[2])
+          .then(commitMessage => {
+            message.channel.send(commitMessage);
+          })
+          .catch(_ => {
+            message.channel.send(_);
+          });
+        break;
+
+      default:
+        // Help
+        message.channel.send(
+          new Discord.RichEmbed()
+            .setDescription('Unrecognized parameter try using:')
+            .addField('pr <repo>', 'View pull requests')
+            .addField('leaderboard <repo>', 'Top 5 contributors')
+            .addField(
+              'commits <repo> <num>',
+              'Merged commits - <num> (optional, Limit: 25)'
+            )
+        );
     }
   },
 });

--- a/src/commands/util/cli-help.js
+++ b/src/commands/util/cli-help.js
@@ -1,0 +1,130 @@
+const Discord = require('discord.js');
+const Command = require('../Command');
+const { gitCommands, npmCommands } = require('../../util/cli-commands');
+
+function getEmbedColor(commandType) {
+  switch (commandType) {
+    case 'git': return 0xF1502F;
+    case 'node':
+    case 'npm': return 0xCB3837;
+  }
+}
+
+function getTitleName(commandType) {
+  switch (commandType) {
+    case 'git': return 'git commands';
+    case 'node':
+    case 'npm': return 'npm commands';
+  }
+}
+
+function getImageUrl(commandType) {
+  switch (commandType) {
+    case 'git':
+      return 'https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png';
+    case 'node':
+    case 'npm':
+      // eslint-disable-next-line
+      return 'https://cdn.freebiesupply.com/logos/large/2x/npm-2-logo-png-transparent.png';
+  }
+}
+
+function getCommandList(commandType) {
+  switch (commandType) {
+    case 'git': return gitCommands;
+    case 'node':
+    case 'npm': return npmCommands;
+  }
+}
+
+module.exports = new Command({
+  name: 'clihelp',
+  description: 'List CLI commands and info about CLI commands',
+  category: 'information',
+  aliases: ['cli-commands'],
+  permissions: 'general',
+  execute: (message, args) => {
+    if (!args.length) {
+      const generalCliHelpEmbed = {
+        color: 0xECB22E,
+        author: {
+          name: 'Welcome to SCEs CLI Helper',
+          // eslint-disable-next-line
+          icon_url: 'https://pngriver.com/wp-content/uploads/2018/04/Download-Cool-PNG-Photos.png',
+        },
+        description: 
+          'Enter any of the following for information on CLI commands',
+        fields: [
+          { name: 'git', value: '`s!clihelp git`', inline: true },
+          { name: 'npm', value: '`s!clihelp npm`', inline: true },
+        ]
+      };
+
+      message.channel.send({ embed: generalCliHelpEmbed });
+    } 
+    else {
+      const commandType = args[0].toLowerCase();
+      // Needs pagination, niche case
+      if (commandType === 'npm' || commandType === 'node') {
+        let pageIndex = 0;
+        const npmCommandEmbed = new Discord.RichEmbed()
+          .setColor(getEmbedColor(commandType))
+          .setAuthor(getTitleName(commandType), getImageUrl(commandType))
+          .addField(npmCommands[pageIndex].name, npmCommands[pageIndex].value)
+          .setFooter(`Page ${pageIndex + 1} of ${npmCommands.length}`);
+        
+        message.channel.send(npmCommandEmbed).then(async sentEmbed => {
+          await sentEmbed.react('⬅️');
+          await sentEmbed.react('➡️');
+
+          const filter = (reaction, user) => {
+            return ['⬅️', '➡️'].includes(reaction.emoji.name) 
+              && user.id === message.author.id;
+          };
+          // Listens to reactions for 1 minute
+          const collector =
+            sentEmbed.createReactionCollector(filter, { time: 60000 });
+          collector.on('collect', reaction => {
+            reaction.remove(reaction.users.last().id);
+            switch(reaction.emoji.name) {
+              case '⬅️':
+                if (pageIndex === 0) return;
+                pageIndex--;
+                break;
+              case '➡️':
+                if (pageIndex === npmCommands.length - 1) {
+                  pageIndex = 0;
+                } else {
+                  pageIndex++;
+                }
+            }
+            const newEmbed = new Discord.RichEmbed()
+              .setColor(getEmbedColor(commandType))
+              .setAuthor(getTitleName(commandType), getImageUrl(commandType))
+              .addField(
+                npmCommands[pageIndex].name,
+                npmCommands[pageIndex].value
+              )
+              .setFooter(`Page ${pageIndex + 1} of ${npmCommands.length}`);
+
+            sentEmbed.edit(newEmbed);
+          });
+        });
+      }
+      // Does not need pagination
+      else {
+        const cliHelpEmbed = {
+          color: getEmbedColor(commandType),
+          author: {
+            name: getTitleName(commandType),
+            // eslint-disable-next-line
+            icon_url: getImageUrl(commandType),
+          },
+          fields: getCommandList(commandType)
+        };
+
+        message.channel.send({ embed: cliHelpEmbed });
+      }     
+    }
+  }
+});

--- a/src/util/cli-commands.js
+++ b/src/util/cli-commands.js
@@ -1,0 +1,51 @@
+module.exports = {
+  gitCommands: [
+    { name: '`git add .`',
+      value: 'Stage all changes in working directory for next commit'
+    },
+    { name: '`git status`',
+      value: 'List which files are staged, unstaged, and untracked'
+    },
+    { name: '`git commit -m "<message>"`',
+      // eslint-disable-next-line
+      value: 'Takes a snapshot of all staged changes, and add a commit message inline'
+    },
+    { name: '`git pull <remote>`',
+      // eslint-disable-next-line
+      value: 'Fetch state of the remote branch and merge it with local branch in one step'
+    },
+    { name: '`git push <remote> <branch>`',
+      // eslint-disable-next-line
+      value: 'Push local branch with commited changes to branch name on remote repository'
+    }
+  ],
+  npmCommands: [
+    { name: '💻 Core-v4 Specific',
+      value:
+        '- `npm install`: Install frontend dependencies\n' +
+        '- `npm run server-install`: Install backend dependencies\n' +
+        '- `npm run start`: Start the frontend\n' +
+        '- `npm run server`: Start the backend\n' +
+        '- `npm run lint`: Run ESLint to clean up your code structure\n' +
+        '- `npm run create-user`: Create a user completely from the CLI\n' +
+        '- `npm run generate-token`: Generate an auth token for Google APIs\n' +
+        // eslint-disable-next-line
+        '- `npm run api-test`: Run API tests to ensure backend logic behaves as expected\n' +
+        // eslint-disable-next-line
+        '- `npm run frontend-test`: Run frontend tests to ensure frontend user-flow behaves as expected\n'
+    },
+    { name: '🖨 SCE-RPC Specific',
+      value:
+        '- `npm install`: Install dependencies\n' +
+        '- `npm run start`: Start the RPC API server\n' +
+        '- `npm run lint`: Run ESLint to clean up your code structure\n' +
+        // eslint-disable-next-line
+        '- `npm run test`: Run API tests to ensure your code behaves as expected\n'
+    },
+    { name: '🤖 SCE-discord-bot Specific',
+      value:
+        '- `npm run start`: Start the server to listen for message events\n' +
+        '- `npm run lint`: Run ESLint to clean up your code structure'
+    }
+  ]
+};


### PR DESCRIPTION
**How to test this** 

- Run the server with `npm start`
- _Must already in SCE-dev discord server_:
    - Type `s!clihelp` in #general for overview
    - Type `s!clihelp git` in #general for git commands
    - Type `s!clihelp npm` or `s!clihelp node` for npm commands, and flip through the pages