### PR TITLE
Warn Fix

### DIFF
--- a/src/commands/admin/mute.js
+++ b/src/commands/admin/mute.js
@@ -71,11 +71,11 @@ module.exports = new Command({
       await user.addRole(targetRole)
         .then(() => {
           if (reason) {
-            message.channel.send(user + ' was muted, **' + reason + '**');
-            user.send('You were muted, **' + reason + '**');
+            message.channel.send(user + ' was **muted**, *' + reason + '*');
+            user.send('You were **muted**, *' + reason + '*');
           } else {
             message.channel.send(user + ' has been **muted**.');
-            user.send('You have been muted. No reason was given.');
+            user.send('You have been **muted**. No reason was given.');
           }
           return;
         });

--- a/src/commands/admin/warn.js
+++ b/src/commands/admin/warn.js
@@ -13,21 +13,23 @@ module.exports = new Command({
       return;
     }
     const author = message.member;
-    const user = message.guild.member(args[0].match(/(\d+)/)[0]);
+    const user = message.guild.member(
+      args[0].match(/(\d+)/)
+      && args[0].match(/(\d+)/)[0]);
     let reason = args.slice(1).join(' ');
     // Check if author can warn
     if (isOfficer(author)) {
       // User must be in the server to warn
-      if (!message.guild.member.id) {
-        message.channel.send('That user doesn\'t exist!');
+      if (!user) {
+        message.channel.send('You need to mention a valid user to mute!');
         return;
       }
       if (reason) {
-        user.send('You were warned, **' + reason + '**');
-        message.channel.send(user + ' warned: ** '
-          + reason + '**');
+        user.send('You were **warned**, *' + reason + '*');
+        message.channel.send(user + ' was **warned**: * '
+          + reason + '*');
       } else {
-        user.send('You have been warned. No reason was given.');
+        user.send('You have been **warned**. No reason was given.');
         message.channel.send(user + ' has been **warned**.');
       }
     } else {


### PR DESCRIPTION
Bot considered a user in the server as an invalid server when applying `s!warn`, so it was patched.

Also, some formatting issues within the bot were made more consistent.

`<mention>` has been **muted/warned**, *reason going here*.