### PR TITLE
Warn/Mute Format Change

### DIFF
--- a/src/commands/admin/mute.js
+++ b/src/commands/admin/mute.js
@@ -71,7 +71,7 @@ module.exports = new Command({
       await user.addRole(targetRole)
         .then(() => {
           if (reason) {
-            message.channel.send(user + `was **muted**, *${reason}*`);
+            message.channel.send(user + ` was **muted**, *${reason}*`);
             user.send(`You were **muted**, *${reason}*`);
           } else {
             message.channel.send(user + ' has been **muted**.');

--- a/src/commands/admin/mute.js
+++ b/src/commands/admin/mute.js
@@ -71,8 +71,8 @@ module.exports = new Command({
       await user.addRole(targetRole)
         .then(() => {
           if (reason) {
-            message.channel.send(user + ' was **muted**, *' + reason + '*');
-            user.send('You were **muted**, *' + reason + '*');
+            message.channel.send(user + `was **muted**, *${reason}*`);
+            user.send(`You were **muted**, *${reason}*`);
           } else {
             message.channel.send(user + ' has been **muted**.');
             user.send('You have been **muted**. No reason was given.');

--- a/src/commands/admin/warn.js
+++ b/src/commands/admin/warn.js
@@ -26,7 +26,7 @@ module.exports = new Command({
       }
       if (reason) {
         user.send(`You were **warned**, *${reason}*`);
-        message.channel.send(user + `You were **warned**, *${reason}*`);
+        message.channel.send(user + ` was **warned**, *${reason}*`);
       } else {
         user.send('You have been **warned**. No reason was given.');
         message.channel.send(user + ' has been **warned**.');

--- a/src/commands/admin/warn.js
+++ b/src/commands/admin/warn.js
@@ -25,9 +25,8 @@ module.exports = new Command({
         return;
       }
       if (reason) {
-        user.send('You were **warned**, *' + reason + '*');
-        message.channel.send(user + ' was **warned**: * '
-          + reason + '*');
+        user.send(`You were **warned**, *${reason}*`);
+        message.channel.send(user + `You were **warned**, *${reason}*`);
       } else {
         user.send('You have been **warned**. No reason was given.');
         message.channel.send(user + ' has been **warned**.');


### PR DESCRIPTION
Warn and mute commands now appear properly formatted, as per the original statement of #88. 