### PR TITLE
Add backend thread creation

### DIFF
--- a/api/models/threadMessage.js
+++ b/api/models/threadMessage.js
@@ -1,18 +1,13 @@
 const mongoose = require('mongoose');
 const { composeMongoose } = require('graphql-compose-mongoose');
 
-
 const ThreadMessageSchema = mongoose.Schema(
   {
     messageID: {
       // ID of discord message
       type: String,
-      required: true
-    },
-    position: {
-      // Position of message in thread
-      type: Number,
-      required: true
+      required: true,
+      unique: true
     },
   },
   { collection: 'threadMessages' }

--- a/api/resolvers/thread.js
+++ b/api/resolvers/thread.js
@@ -1,26 +1,72 @@
 const {
-  ThreadTC
+  ThreadTC,
+  Thread,
 } = require('../models/thread');
+const { ThreadMessage } = require('../models/threadMessage');
 
 const ThreadQuery = {
-  threadById: ThreadTC.mongooseResolvers.findById(),
-  threadByIds: ThreadTC.mongooseResolvers.findByIds(),
   threadOne: ThreadTC.mongooseResolvers.findOne(),
   threadMany: ThreadTC.mongooseResolvers.findMany(),
   threadCount: ThreadTC.mongooseResolvers.count(),
-  threadConnection: ThreadTC.mongooseResolvers.connection(),
-  threadPagination: ThreadTC.mongooseResolvers.pagination(),
 };
 
 const ThreadMutation = {
   threadCreateOne: ThreadTC.mongooseResolvers.createOne(),
-  threadCreateMany: ThreadTC.mongooseResolvers.createMany(),
-  threadUpdateById: ThreadTC.mongooseResolvers.updateById(),
   threadUpdateOne: ThreadTC.mongooseResolvers.updateOne(),
-  threadUpdateMany: ThreadTC.mongooseResolvers.updateMany(),
-  threadRemoveById: ThreadTC.mongooseResolvers.removeById(),
   threadRemoveOne: ThreadTC.mongooseResolvers.removeOne(),
   threadRemoveMany: ThreadTC.mongooseResolvers.removeMany(),
+  threadAddMessage: {
+    type: ThreadTC,
+    args: { threadID: 'String!', messageID: 'String!' },
+    resolve: async (source, args) => {
+      const message = await ThreadMessage.create({
+        messageID: args.messageID
+      });
+      // error
+      if (!message) return null;
+
+      const thread = await Thread.findOneAndUpdate(
+        { threadID: args.threadID },
+        { $addToSet: { threadMessages: message } },
+        { new: true }
+      );
+      return thread;
+    }
+  },
+  threadCreate: {
+    type: ThreadTC,
+    args: {
+      threadID: 'String!',
+      creatorID: 'String!',
+      guildID: 'String!',
+      topic: 'String',
+      messageID: 'String!',
+    },
+    resolve: async (source, args) => {
+      const {
+        threadID,
+        creatorID,
+        guildID,
+        topic,
+        messageID,
+      } = args;
+      const message = await ThreadMessage.create({
+        messageID
+      });
+      // error
+      if (!message) return null;
+
+      const thread = await Thread.create({
+        threadID,
+        creatorID,
+        guildID,
+        topic,
+        threadMessages: [message]
+      });
+      if (!thread) return null;
+      return thread;
+    }
+  }
 };
 
 module.exports = { ThreadQuery, ThreadMutation };

--- a/api/resolvers/threadMessage.js
+++ b/api/resolvers/threadMessage.js
@@ -3,22 +3,14 @@ const {
 } = require('../models/threadMessage');
 
 const ThreadMessageQuery = {
-  threadMessageById: ThreadMessageTC.mongooseResolvers.findById(),
-  threadMessageByIds: ThreadMessageTC.mongooseResolvers.findByIds(),
   threadMessageOne: ThreadMessageTC.mongooseResolvers.findOne(),
   threadMessageMany: ThreadMessageTC.mongooseResolvers.findMany(),
   threadMessageCount: ThreadMessageTC.mongooseResolvers.count(),
-  threadMessageConnection: ThreadMessageTC.mongooseResolvers.connection(),
-  threadMessagePagination: ThreadMessageTC.mongooseResolvers.pagination(),
 };
 
 const ThreadMessageMutation = {
   threadMessageCreateOne: ThreadMessageTC.mongooseResolvers.createOne(),
-  threadMessageCreateMany: ThreadMessageTC.mongooseResolvers.createMany(),
-  threadMessageUpdateById: ThreadMessageTC.mongooseResolvers.updateById(),
   threadMessageUpdateOne: ThreadMessageTC.mongooseResolvers.updateOne(),
-  threadMessageUpdateMany: ThreadMessageTC.mongooseResolvers.updateMany(),
-  threadMessageRemoveById: ThreadMessageTC.mongooseResolvers.removeById(),
   threadMessageRemoveOne: ThreadMessageTC.mongooseResolvers.removeOne(),
   threadMessageRemoveMany: ThreadMessageTC.mongooseResolvers.removeMany(),
 };

--- a/src/APIFunctions/ApiResponses.js
+++ b/src/APIFunctions/ApiResponses.js
@@ -1,0 +1,15 @@
+/**
+ * Class to hold the server responses
+ * @member {bool} error - Lets us know if there was any error regarding
+ * the API call. This variable should be false if there was no error.
+ * @member {any} responseData - Contains anything we would like to return
+ * from the API call (e.g. object array or error data)
+ * @member {string|null} token - An authentication token
+ */
+export class ApiResponse {
+  constructor(error = false, responseData = null) {
+    this.error = error;
+    this.responseData = responseData;
+  }
+}
+

--- a/src/APIFunctions/thread.js
+++ b/src/APIFunctions/thread.js
@@ -1,5 +1,6 @@
 const { request, gql } = require('graphql-request');
 const { url } = require('../../config.json');
+const { ApiResponse } = require('./ApiResponses');
 
 const THREAD_QUERY = async () => {
   const query = gql`
@@ -11,16 +12,92 @@ const THREAD_QUERY = async () => {
       topic
       messages {
         messageID
-        position
       }
     }
   }
   `;
-  let response = {};
+  let response = new ApiResponse();
   await request(`${url}/graphql`, query)
     .then((data) => {
-      response.data = data;
+      response.responseData = data;
       response.error = false;
+    })
+    .catch(() => {
+      response.error = true;
+    });
+  return response;
+};
+
+const CREATE_THREAD = async (data) => {
+  const {
+    threadID,
+    creatorID,
+    guildID,
+    topic,
+    messageID
+  } = data;
+  let response = new ApiResponse();
+
+  // Create the thread message
+  const makeThreadMessage = gql`
+  mutation {
+    threadCreate(
+      threadID:"${threadID}",
+      creatorID:"${creatorID}",
+      guildID:"${guildID}",
+      topic:"${topic}",
+      messageID:"${messageID}"
+    ) {
+      threadID
+      creatorID
+      guildID
+      topic
+      threadMessages {
+        messageID
+      }
+    }
+  }
+  `;
+
+  await request(`${url}/graphql`, makeThreadMessage)
+    .then((data) => {
+      response.data = data;
+    })
+    .catch(() => {
+      response.data = {};
+      response.error = true;
+    });
+  return response;
+};
+
+const ADD_THREADMESSAGE = async (data) => {
+  const {
+    threadID,
+    messageID
+  } = data;
+  let response = new ApiResponse();
+
+  // Create the thread message
+  const makeThreadMessage = gql`
+  mutation { 
+    threadAddMessage(
+      threadID:"${threadID}",
+      messageID:"${messageID}"
+    ) {
+      threadID
+      creatorID
+      guildID
+      topic
+      threadMessages {
+        messageID
+      }
+    }
+  }
+  `;
+
+  await request(`${url}/graphql`, makeThreadMessage)
+    .then((data) => {
+      response.data = data;
     })
     .catch(() => {
       response.data = {};
@@ -30,5 +107,7 @@ const THREAD_QUERY = async () => {
 };
 
 module.exports = {
-  THREAD_QUERY
+  THREAD_QUERY,
+  CREATE_THREAD,
+  ADD_THREADMESSAGE,
 };

--- a/src/commands/member_services/joinStudychannel.js
+++ b/src/commands/member_services/joinStudychannel.js
@@ -18,7 +18,7 @@ module.exports = new Command({
     }
     const targetClass = args[0].toLowerCase();
 
-    // Assign the role
+    // Get role to be assigned
     let classRole = roles.array().filter(
       (x) => x.name == targetClass
     );
@@ -55,9 +55,10 @@ module.exports = new Command({
     // If role exists - change its permissions
     if (classRole.length > 0) {
       targetRole = classRole[0];
-      // Assign the role to the user
 
+      // Assign the role to the user
       if (author.roles.array().map((x) => x.name).includes(targetClass)) {
+        // If user has the role, remove them from the class
         await author.removeRole(targetRole)
           .then(() =>
             message.channel.send(author + ` has left the ${targetClass} `
@@ -65,6 +66,7 @@ module.exports = new Command({
           );
       }
       else {
+        // Subscribe user to a class
         await author.addRole(targetRole)
           .then(() =>
             message.channel.send(author + ` has joined ${targetClass}`)


### PR DESCRIPTION
Refactors:
Removed position of threadMessage because mongoDB retains the order

Custom resolvers created: 
1. `threadAddMessage` - Add message to an existing thread
1. `threadCreate` - Create a thread with a single threadmessage

Queries implemented
1. `CREATE_THREAD`
1. `ADD_THREADMESSAGE`

Next steps:
1. On cascade delete
1. Error handling