### PR TITLE
try/catch in isOfficer

### DIFF
--- a/src/util/Permission.js
+++ b/src/util/Permission.js
@@ -1,8 +1,12 @@
 function isOfficer(user) {
-  return (
-    user.permissions.has('MANAGE_CHANNELS') ||
-    user.permissions.has('ADMINISTRATOR')
-  );
+  try {
+    return (
+      user.permissions.has('MANAGE_CHANNELS') ||
+      user.permissions.has('ADMINISTRATOR')
+    );
+  } catch (error) {
+    return false;
+  }
 }
 
 function isAdmin(user) {


### PR DESCRIPTION
to prevent the below error
```
WARNING: ytdl-core is out of date! Update with "npm install ytdl-core@latest".
/bot/node_modules/discord.js/src/util/BitField.js:172
    throw new DiscordjsRangeError(ErrorCodes.BitFieldInvalid, bit);
          ^

RangeError [BitFieldInvalid]: Invalid bitfield flag or number: MANAGE_CHANNELS.
    at PermissionsBitField.resolve (/bot/node_modules/discord.js/src/util/BitField.js:172:11)
    at PermissionsBitField.has (/bot/node_modules/discord.js/src/util/BitField.js:60:28)
    at PermissionsBitField.has (/bot/node_modules/discord.js/src/util/PermissionsBitField.js:92:82)
    at isOfficer (/bot/src/util/Permission.js:3:22)
    at /bot/src/commands/util/help.js:22:47
    at /bot/node_modules/@discordjs/collection/dist/index.js:239:14
    at Function.from (<anonymous>)
    at Collection.map (/bot/node_modules/@discordjs/collection/dist/index.js:237:18)
    at Command.execute [as executeCommand] (/bot/src/commands/util/help.js:21:34)
    at Command.execute (/bot/src/commands/Command.js:14:10) {
  code: 'BitFieldInvalid'
}
```