### PR TITLE
Conditionally send caught errors to specified Discord channel

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,5 +3,6 @@
     "DISCORD_API_URL": "http://localhost:5000",
     "prefix": "s!",
     "SCE_API_URL": "http://sce.engr.sjsu.edu",
+    "ERROR_CHANNEL_ID": "xxxxxxxxxxxxxx",
     "CORE_V4_API_KEY" : "xxxxxxxxxxxxxx"
 }

--- a/src/commands/Command.js
+++ b/src/commands/Command.js
@@ -1,3 +1,49 @@
+const { ERROR_CHANNEL_ID = null } = require('../../config.json');
+const { EmbedBuilder } = require('discord.js');
+const util = require('util');
+
+/**
+ * Log an error to both stderr and conditionally send an embed with error
+ * information to a discord channel. The discord channel will only be sent
+ * a message if the ERROR_CHANNEL_ID field in config.json is a numerical id.
+ * @param {Object} message Discord js Message object. For more information see
+ * https://old.discordjs.dev/#/docs/discord.js/14.11.0/class/Message
+ * @param {Object} error Normal JavaScript error
+ */
+function logError(message, error) {
+  try {
+    console.error(error);
+    const channel = message.client.channels.cache.find(
+      channel => channel.id === ERROR_CHANNEL_ID
+    );
+    if (!channel) {
+      // If the channel is not found skip sending the embed
+      return;
+    }
+    const exampleEmbed = new EmbedBuilder()
+      .setColor(0x990000)
+      .setTitle('SCE Discord Bot Error')
+      .setDescription('```\n' + ` ${util.inspect(error)} ` + '\n```')
+      .addFields(
+        { name: 'Author', value: message.author.username },
+        { name: `Original message: ${message.url}`, value: message.content },
+        {
+          name: 'Message timestamp',
+          value: new Date(message.createdTimestamp).toISOString(),
+        },
+      );
+    channel.send({ embeds: [exampleEmbed] });
+  } catch (anotherError) {
+    // For some reason if the above code throws a new error, we need
+    // to catch it so we dont crash the bot. When this happens log
+    // both errors to stderr.
+    console.error(
+      'while handling the above error, another error occurred:',
+      anotherError,
+    );
+  }
+}
+
 module.exports = class Command {
   constructor(args) {
     this.name = args.name;
@@ -11,6 +57,10 @@ module.exports = class Command {
   }
 
   async execute(message, args) {
-    this.executeCommand(message, args);
+    try {
+      this.executeCommand(message, args);
+    } catch (error) {
+      logError(message, error);
+    }
   }
 };


### PR DESCRIPTION
Now, specifying `ERROR_CHANNEL_ID` in config.json will have an embed sent to the channel if any uncaught exception is thrown. We also prevent the bot from crashing due to uncaught exceptions

<img width="625" alt="image" src="https://github.com/SCE-Development/SCE-discord-bot/assets/36345325/e2db3e30-8b4c-45a0-8922-88b909b29588">
